### PR TITLE
Add support for CF-Connecting-IP and X-Real-IP headers

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -10,6 +10,7 @@ const path = require('path');
 // Import services and middleware
 const db = require('./db/database');
 const { runMigration } = require('./db/migration');
+const extractRealIp = require('./middleware/ipMiddleware');
 
 // Load routes
 const authRoutes = require('./api/auth');
@@ -23,6 +24,9 @@ const { handleAuthError } = require('./middleware/authMiddleware');
 // Initialize Express app
 const app = express();
 const server = http.createServer(app);
+
+// Configure Express to trust proxy headers
+app.set('trust proxy', true);
 
 // Initialize Socket.IO with permissive CORS for LAN compatibility
 const io = socketIo(server, {
@@ -90,10 +94,13 @@ const generalLimiter = rateLimit({
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
+// IP extraction middleware
+app.use(extractRealIp);
+
 // Request logging middleware
 app.use((req, res, next) => {
   const timestamp = new Date().toISOString();
-  console.log(`${timestamp} ${req.method} ${req.path} - ${req.ip}`);
+  console.log(`${timestamp} ${req.method} ${req.path} - ${req.realIp || req.ip}`);
   
   // Add response header logging
   const originalSend = res.send;

--- a/server/src/middleware/ipMiddleware.js
+++ b/server/src/middleware/ipMiddleware.js
@@ -1,0 +1,44 @@
+/**
+ * IP extraction middleware
+ * Extracts real client IP from various proxy headers
+ */
+
+const extractRealIp = (req, res, next) => {
+  let realIp = null;
+
+  // Priority order for IP extraction:
+  // 1. CF-Connecting-IP (Cloudflare)
+  // 2. X-Real-IP (Common proxy header)
+  // 3. X-Forwarded-For (Standard proxy header, first IP)
+  // 4. req.connection.remoteAddress (fallback)
+  // 5. req.ip (Express default)
+
+  const cfConnectingIp = req.headers['cf-connecting-ip'];
+  const xRealIp = req.headers['x-real-ip'];
+  const xForwardedFor = req.headers['x-forwarded-for'];
+
+  if (cfConnectingIp && typeof cfConnectingIp === 'string') {
+    realIp = cfConnectingIp.trim();
+  } else if (xRealIp && typeof xRealIp === 'string') {
+    realIp = xRealIp.trim();
+  } else if (xForwardedFor && typeof xForwardedFor === 'string') {
+    // X-Forwarded-For can contain multiple IPs, take the first one
+    realIp = xForwardedFor.split(',')[0].trim();
+  } else if (req.connection && req.connection.remoteAddress) {
+    realIp = req.connection.remoteAddress;
+  } else {
+    realIp = req.ip;
+  }
+
+  // Clean up IPv6-mapped IPv4 addresses
+  if (realIp && realIp.startsWith('::ffff:')) {
+    realIp = realIp.substring(7);
+  }
+
+  // Set the real IP on the request object
+  req.realIp = realIp;
+  
+  next();
+};
+
+module.exports = extractRealIp; 


### PR DESCRIPTION
## Summary
Added middleware to extract real client IP addresses from proxy headers, with support for Cloudflare's `CF-Connecting-IP` and common `X-Real-IP` headers.

## Changes
- **New middleware**: `server/src/middleware/ipMiddleware.js`
  - Extracts real client IP from headers in priority order:
    1. `CF-Connecting-IP` (Cloudflare)
    2. `X-Real-IP` (Common proxy header)  
    3. `X-Forwarded-For` (Standard proxy header)
    4. Connection remote address (fallback)
    5. Express default IP (final fallback)
  - Handles IPv6-mapped IPv4 addresses cleanup
  - Sets `req.realIp` on request object

- **Updated main application** (`server/src/app.js`):
  - Added Express proxy trust configuration
  - Integrated IP extraction middleware
  - Updated request logging to use real IP addresses

## Benefits
- Proper IP detection behind proxies, CDNs, and load balancers
- More accurate rate limiting based on actual client IPs
- Better security logging and monitoring
- Cloudflare compatibility out of the box

## Testing
The middleware automatically detects and uses the most reliable IP source available from the request headers and connection information.