### PR TITLE
Fix encryption service initialization

### DIFF
--- a/server/src/services/encryptionService.js
+++ b/server/src/services/encryptionService.js
@@ -11,13 +11,15 @@ class EncryptionService {
   async init() {
     try {
       if (this.initialized && this.key) return;
-      
+
       await this.loadEncryptionKey();
       this.initialized = true;
     } catch (error) {
       console.error('Failed to initialize Encryption Service:', error);
       // Fall back to environment variable or generate a random key
       this.key = this.getFallbackEncryptionKey();
+      // Mark as initialized even when falling back so we don't retry on every call
+      this.initialized = true;
     }
   }
   


### PR DESCRIPTION
## Summary
- ensure encryptionService is marked initialized when fallback key is used

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684868896608832e9fe9a5f17aa463fa